### PR TITLE
refactor: code consistency improvements across chart classes

### DIFF
--- a/src/charts/ComboChart.ts
+++ b/src/charts/ComboChart.ts
@@ -1,4 +1,4 @@
-import type * as d3 from "d3";
+import * as d3 from "d3";
 import { CartesianChart } from "./CartesianChart";
 import { AxisTypes, ScaleTypes, SeriesTypes } from "../types/enums";
 import type { IDatum, IChartData, IOptions } from "../types/interfaces";

--- a/src/charts/LineChart.ts
+++ b/src/charts/LineChart.ts
@@ -1,4 +1,4 @@
-import type * as d3 from "d3";
+import * as d3 from "d3";
 import { CartesianChart } from "./CartesianChart";
 import { AxisTypes, ScaleTypes, StackTypes } from "../types/enums";
 import type { IDatum, IChartData, IOptions } from "../types/interfaces";

--- a/src/charts/VariwideChart.ts
+++ b/src/charts/VariwideChart.ts
@@ -63,7 +63,8 @@ export class VariwideChart extends CartesianChart {
     // Replace the default numeric ticks with category labels at column midpoints
     this._patchXAxisTicks(xIdx, cumulative, weights);
 
-    const svgSeries = this.canvas.plotArea.svg
+    const pa        = this.canvas.plotArea;
+    const svgSeries = pa.svg
       .append("g")
       .attr("class", "series") as unknown as d3.Selection<SVGGElement, unknown, d3.BaseType, unknown>;
 


### PR DESCRIPTION
- VariwideChart: add pa alias for this.canvas.plotArea in draw(), matching the pattern used by HeatmapChart and all non-Cartesian charts
- ComboChart, LineChart: change 'import type * as d3' to 'import * as d3' so runtime d3 values are available alongside type-only usage